### PR TITLE
retab to 4 spaces and static analysis fixes

### DIFF
--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -1,7 +1,7 @@
 /*
  * spectcl.js: Top-level include for the `spectcl` module.
  *
- * (C) 2015, Greg Cochard.
+ * (C) 2015, Greg Cochard, Ryan Milbourne
  * (C) 2011, Elijah Insua, Marak Squires, Charlie Robbins.
  *
  */
@@ -11,391 +11,400 @@ var util = require('util');
 var AssertionError = require('assert').AssertionError;
 var EventEmitter = require('events').EventEmitter;
 
-function chain (context) {
-  return {
-    expect: function (expectation) {
-      var _expect = function _expect (data) {
-        return testExpectation(data, expectation);
-      };
-
-      _expect.shift = true;
-      _expect.expectation = expectation;
-      _expect.description = '[expect] ' + expectation;
-      _expect.requiresInput = true;
-      context.queue.push(_expect);
-
-      return chain(context);
-    },
-    wait: function (expectation, callback) {
-      var _wait = function _wait (data) {
-        var val = testExpectation(data, expectation);
-        if (val === true && typeof callback === 'function') {
-          callback(data);
-        }
-        return val;
-      };
-
-      _wait.shift = false;
-      _wait.expectation = expectation;
-      _wait.description = '[wait] ' + expectation;
-      _wait.requiresInput = true;
-      context.queue.push(_wait);
-      return chain(context);
-    },
-    on: function() {
-        context.on.apply(this, arguments);
-    },
-    sendline: function (line) {
-      var _sendline = function _sendline () {
-        context.process.stdin.write(line + '\n');
-
-        if (context.verbose) {
-          process.stdout.write(line + '\n');
-        }
-      };
-
-      _sendline.shift = true;
-      _sendline.description = '[sendline] ' + line;
-      _sendline.requiresInput = false;
-      context.queue.push(_sendline);
-      return chain(context);
-    },
-    sendEof: function() {
-      var _sendEof = function _sendEof () {
-        context.process.stdin.destroy();
-      };
-      _sendEof.shift = true;
-      _sendEof.description = '[sendEof]';
-      _sendEof.requiresInput = false;
-      context.queue.push(_sendEof);
-      return chain(context);
-    },
-    run: function (callback) {
-      var errState = null,
-          responded = false,
-          stdout = [],
-          options;
-
-      //
-      // **onError**
-      //
-      // Helper function to respond to the callback with a
-      // specified error. Kills the child process if necessary.
-      //
-      function onError (err, kill) {
-        if (errState || responded) {
-          return;
-        }
-
-        errState = err;
-        responded = true;
-
-        if (kill) {
-          try { context.process.kill(); }
-          catch (ex) { }
-        }
-
-        callback(err);
-      }
-
-      //
-      // **validateFnType**
-      //
-      // Helper function to validate the `currentFn` in the
-      // `context.queue` for the target chain.
-      //
-      function validateFnType (currentFn) {
-        if (typeof currentFn !== 'function') {
-          //
-          // If the `currentFn` is not a function, short-circuit with an error.
-          //
-          onError(new Error('Cannot process non-function on nexpect stack.'), true);
-          return false;
-        }
-        else if (['_expect', '_sendline', '_wait', '_sendEof'].indexOf(currentFn.name) === -1) {
-          //
-          // If the `currentFn` is a function, but not those set by `.sendline()` or
-          // `.expect()` then short-circuit with an error.
-          //
-          onError(new Error('Unexpected context function name: ' + currentFn.name), true);
-          return false;
-        }
-
-        return true;
-      }
-
-      //
-      // **evalContext**
-      //
-      // Core evaluation logic that evaluates the next function in
-      // `context.queue` against the specified `data` where the last
-      // function run had `name`.
-      //
-      function evalContext (data, name) {
-        var currentFn = context.queue[0];
-
-        if (!currentFn || (name === '_expect' && currentFn.name === '_expect')) {
-          //
-          // If there is nothing left on the context or we are trying to
-          // evaluate two consecutive `_expect` functions, return.
-          //
-          return;
-        }
-
-        if (currentFn.shift) {
-          context.queue.shift();
-        }
-
-        if (!validateFnType(currentFn)) {
-          return;
-        }
-
-        if (currentFn.name === '_expect') {
-          //
-          // If this is an `_expect` function, then evaluate it and attempt
-          // to evaluate the next function (in case it is a `_sendline` function).
-          //
-          context.emit('expect');
-          return currentFn(data) === true ?
-            evalContext(data, '_expect') :
-            onError(createExpectationError(currentFn.expectation, data), true);
-        }
-        else if (currentFn.name === '_wait') {
-          //
-          // If this is a `_wait` function, then evaluate it and if it returns true,
-          // then evaluate the function (in case it is a `_sendline` function).
-          //
-          if (currentFn(data) === true) {
-            context.emit('wait',data);
-            context.queue.shift();
-            evalContext(data, '_expect');
-          }
-        }
-        else {
-          //
-          // If the `currentFn` is any other function then evaluate it
-          //
-          currentFn();
-
-          // Evaluate the next function if it does not need input
-          var nextFn = context.queue[0];
-          if (nextFn && !nextFn.requiresInput)
-            evalContext(data);
-        }
-      }
-
-      //
-      // **onLine**
-      //
-      // Preprocesses the `data` from `context.process` on the
-      // specified `context.stream` and then evaluates the processed lines:
-      //
-      // 1. Stripping ANSI colors (if necessary)
-      // 2. Removing case sensitivity (if necessary)
-      // 3. Splitting `data` into multiple lines.
-      //
-      function onLine (data) {
-        data = data.toString();
-
-        if (context.stripColors) {
-          data = data.replace(/\u001b\[\d{0,2}m/g, '');
-        }
-
-        if (context.ignoreCase) {
-          data = data.toLowerCase();
-        }
-
-        var lines = data.split('\n').filter(function (line) { return line.length > 0; });
-        stdout = stdout.concat(lines);
-
-        while (lines.length > 0) {
-          evalContext(lines.shift(), null);
-        }
-      }
-
-      //
-      // **flushQueue**
-      //
-      // Helper function which flushes any remaining functions from
-      // `context.queue` and responds to the `callback` accordingly.
-      //
-      function flushQueue () {
-        var remainingQueue = context.queue.slice(),
-            currentFn = context.queue.shift(),
-            lastLine = stdout[stdout.length - 1];
-
-        if (!lastLine) {
-          onError(createUnexpectedEndError(
-            'No data from child with non-empty queue.', remainingQueue));
-          return false;
-        }
-        else if (context.queue.length > 0) {
-          onError(createUnexpectedEndError(
-            'Non-empty queue on spawn exit.', remainingQueue));
-          return false;
-        }
-        else if (!validateFnType(currentFn)) {
-          // onError was called
-          return false;
-        }
-        else if (currentFn.name === '_sendline') {
-          onError(new Error('Cannot call sendline after the process has exited'));
-          return false;
-        }
-        else if (currentFn.name === '_wait' || currentFn.name === '_expect') {
-          if (currentFn(lastLine) !== true) {
-            onError(createExpectationError(currentFn.expectation, lastLine));
-            return false;
-          }
-        }
-
-        return true;
-      }
-
-      //
-      // **onData**
-      //
-      // Helper function for writing any data from a stream
-      // to `process.stdout`.
-      //
-      function onData (data) {
-        process.stdout.write(data);
-      }
-
-      options = {
-        cwd: context.cwd,
-        env: context.env
-      };
-
-      //
-      // Spawn the child process and begin processing the target
-      // stream for this chain.
-      //
-      context.process = spawn(context.command, context.params, options);
-
-      if (context.verbose) {
-        context.process.stdout.on('data', onData);
-        context.process.stderr.on('data', onData);
-      }
-
-      if (context.stream === 'all') {
-        context.process.stdout.on('data', onLine);
-        context.process.stderr.on('data', onLine);
-      } else {
-        context.process[context.stream].on('data', onLine);
-      }
-
-      context.process.on('error', onError);
-
-      //
-      // When the process exits, check the output `code` and `signal`,
-      // flush `context.queue` (if necessary) and respond to the callback
-      // appropriately.
-      //
-      context.process.on('close', function (code, signal) {
-        if (code === 127) {
-          // XXX(sam) Not how node works (anymore?), 127 is what /bin/sh returns,
-          // but it appears node does not, or not in all conditions, blithely
-          // return 127 to user, it emits an 'error' from the child_process.
-
-          //
-          // If the response code is `127` then `context.command` was not found.
-          //
-          return onError(new Error('Command not found: ' + context.command));
-        }
-        else if (context.queue.length && !flushQueue()) {
-          // if flushQueue returned false, onError was called
-          return;
-        }
-
-        callback(null, stdout, signal || code);
-      });
-
-      return context;
-    }
-  };
-}
-
 function testExpectation(data, expectation) {
-  if (util.isRegExp(expectation)) {
-    return expectation.test(data);
-  } else {
+    if (util.isRegExp(expectation)) {
+        return expectation.test(data);
+    }
     return data.indexOf(expectation) > -1;
-  }
 }
 
 function createUnexpectedEndError(message, remainingQueue) {
-  var desc = remainingQueue.map(function(it) { return it.description; });
-  var msg = message + '\n' + desc.join('\n');
-  return new AssertionError({
-    message: msg,
-    expected: [],
-    actual: desc
-  });
+    var desc = remainingQueue.map(function(it) { return it.description; });
+    var msg = message + '\n' + desc.join('\n');
+    return new AssertionError({
+        message: msg,
+        expected: [],
+        actual: desc
+    });
 }
 
 function createExpectationError(expected, actual) {
-  var expectation;
-  if (util.isRegExp(expected))
-    expectation = 'to match ' + expected;
-  else
-    expectation = 'to contain ' + JSON.stringify(expected);
+    var expectation;
+    if (util.isRegExp(expected)){
+        expectation = 'to match ' + expected;
+    } else {
+        expectation = 'to contain ' + JSON.stringify(expected);
+    }
 
-  var err = new AssertionError({
-    message: util.format('expected %j %s', actual, expectation),
-    actual: actual,
-    expected: expected
-  });
-  return err;
+    var err = new AssertionError({
+        message: util.format('expected %j %s', actual, expectation),
+        actual: actual,
+        expected: expected
+    });
+    return err;
+}
+
+function chain (context) {
+    return {
+        expect: function (expectation) {
+            var _expect = function _expect (data) {
+                return testExpectation(data, expectation);
+            };
+
+            _expect.shift = true;
+            _expect.expectation = expectation;
+            _expect.description = '[expect] ' + expectation;
+            _expect.requiresInput = true;
+            context.queue.push(_expect);
+
+            return chain(context);
+        },
+        wait: function (expectation, callback) {
+            var _wait = function _wait (data) {
+                var val = testExpectation(data, expectation);
+                if (val === true && typeof callback === 'function') {
+                    callback(data);
+                }
+                return val;
+            };
+
+            _wait.shift = false;
+            _wait.expectation = expectation;
+            _wait.description = '[wait] ' + expectation;
+            _wait.requiresInput = true;
+            context.queue.push(_wait);
+            return chain(context);
+        },
+        on: function() {
+                context.on.apply(this, arguments);
+        },
+        sendline: function (line) {
+            var _sendline = function _sendline () {
+                context.process.stdin.write(line + '\n');
+
+                if (context.verbose) {
+                    process.stdout.write(line + '\n');
+                }
+            };
+
+            _sendline.shift = true;
+            _sendline.description = '[sendline] ' + line;
+            _sendline.requiresInput = false;
+            context.queue.push(_sendline);
+            return chain(context);
+        },
+        sendEof: function() {
+            var _sendEof = function _sendEof () {
+                context.process.stdin.destroy();
+            };
+            _sendEof.shift = true;
+            _sendEof.description = '[sendEof]';
+            _sendEof.requiresInput = false;
+            context.queue.push(_sendEof);
+            return chain(context);
+        },
+        run: function (callback) {
+            var errState = null,
+                    responded = false,
+                    stdout = [],
+                    options;
+
+            //
+            // **onError**
+            //
+            // Helper function to respond to the callback with a
+            // specified error. Kills the child process if necessary.
+            //
+            function onError (err, kill) {
+                if (errState || responded) {
+                    return;
+                }
+
+                errState = err;
+                responded = true;
+
+                if (kill) {
+                    try { context.process.kill(); }
+                    catch (ignore) { }
+                }
+
+                callback(err);
+            }
+
+            //
+            // **validateFnType**
+            //
+            // Helper function to validate the `currentFn` in the
+            // `context.queue` for the target chain.
+            //
+            function validateFnType (currentFn) {
+                if (typeof currentFn !== 'function') {
+                    //
+                    // If the `currentFn` is not a function, short-circuit with an error.
+                    //
+                    onError(new Error('Cannot process non-function on nexpect stack.'), true);
+                    return false;
+                }
+
+                if (['_expect', '_sendline', '_wait', '_sendEof'].indexOf(currentFn.name) === -1) {
+                    //
+                    // If the `currentFn` is a function, but not those set by `.sendline()` or
+                    // `.expect()` then short-circuit with an error.
+                    //
+                    onError(new Error('Unexpected context function name: ' + currentFn.name), true);
+                    return false;
+                }
+
+                return true;
+            }
+
+            //
+            // **evalContext**
+            //
+            // Core evaluation logic that evaluates the next function in
+            // `context.queue` against the specified `data` where the last
+            // function run had `name`.
+            //
+            function evalContext (data, name) {
+                var currentFn = context.queue[0];
+
+                if (!currentFn || (name === '_expect' && currentFn.name === '_expect')) {
+                    //
+                    // If there is nothing left on the context or we are trying to
+                    // evaluate two consecutive `_expect` functions, return.
+                    //
+                    return;
+                }
+
+                if (currentFn.shift) {
+                    context.queue.shift();
+                }
+
+                if (!validateFnType(currentFn)) {
+                    return;
+                }
+
+                if (currentFn.name === '_expect') {
+                    //
+                    // If this is an `_expect` function, then evaluate it and attempt
+                    // to evaluate the next function (in case it is a `_sendline` function).
+                    //
+                    context.emit('expect');
+                    return currentFn(data) === true ?
+                        evalContext(data, '_expect') :
+                        onError(createExpectationError(currentFn.expectation, data), true);
+                }
+
+                if (currentFn.name === '_wait') {
+                    //
+                    // If this is a `_wait` function, then evaluate it and if it returns true,
+                    // then evaluate the function (in case it is a `_sendline` function).
+                    //
+                    if (currentFn(data) === true) {
+                        context.emit('wait',data);
+                        context.queue.shift();
+                        evalContext(data, '_expect');
+                    }
+                } else {
+                    //
+                    // If the `currentFn` is any other function then evaluate it
+                    //
+                    currentFn();
+
+                    // Evaluate the next function if it does not need input
+                    var nextFn = context.queue[0];
+                    if (nextFn && !nextFn.requiresInput) {
+                        evalContext(data);
+                    }
+                }
+            }
+
+            //
+            // **onLine**
+            //
+            // Preprocesses the `data` from `context.process` on the
+            // specified `context.stream` and then evaluates the processed lines:
+            //
+            // 1. Stripping ANSI colors (if necessary)
+            // 2. Removing case sensitivity (if necessary)
+            // 3. Splitting `data` into multiple lines.
+            //
+            function onLine (data) {
+                data = data.toString();
+
+                if (context.stripColors) {
+                    data = data.replace(/\u001b\[\d{0,2}m/g, '');
+                }
+
+                if (context.ignoreCase) {
+                    data = data.toLowerCase();
+                }
+
+                var lines = data.split('\n').filter(function (line) { return line.length > 0; });
+                stdout = stdout.concat(lines);
+
+                while (lines.length > 0) {
+                    evalContext(lines.shift(), null);
+                }
+            }
+
+            //
+            // **flushQueue**
+            //
+            // Helper function which flushes any remaining functions from
+            // `context.queue` and responds to the `callback` accordingly.
+            //
+            function flushQueue () {
+                var remainingQueue = context.queue.slice(),
+                        currentFn = context.queue.shift(),
+                        lastLine = stdout[stdout.length - 1];
+
+                if (!lastLine) {
+                    onError(createUnexpectedEndError(
+                        'No data from child with non-empty queue.', remainingQueue));
+                    return false;
+                }
+
+                if (context.queue.length > 0) {
+                    onError(createUnexpectedEndError(
+                        'Non-empty queue on spawn exit.', remainingQueue));
+                    return false;
+                }
+
+                if (!validateFnType(currentFn)) {
+                    // onError was called
+                    return false;
+                }
+
+                if (currentFn.name === '_sendline') {
+                    onError(new Error(
+                        'Cannot call sendline after the process has exited'));
+                    return false;
+                }
+
+                if (currentFn.name === '_wait' || currentFn.name === '_expect') {
+                    if (currentFn(lastLine) !== true) {
+                        onError(createExpectationError(currentFn.expectation, lastLine));
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            //
+            // **onData**
+            //
+            // Helper function for writing any data from a stream
+            // to `process.stdout`.
+            //
+            function onData (data) {
+                process.stdout.write(data);
+            }
+
+            options = {
+                cwd: context.cwd,
+                env: context.env
+            };
+
+            //
+            // Spawn the child process and begin processing the target
+            // stream for this chain.
+            //
+            context.process = spawn(context.command, context.params, options);
+
+            if (context.verbose) {
+                context.process.stdout.on('data', onData);
+                context.process.stderr.on('data', onData);
+            }
+
+            if (context.stream === 'all') {
+                context.process.stdout.on('data', onLine);
+                context.process.stderr.on('data', onLine);
+            } else {
+                context.process[context.stream].on('data', onLine);
+            }
+
+            context.process.on('error', onError);
+
+            //
+            // When the process exits, check the output `code` and `signal`,
+            // flush `context.queue` (if necessary) and respond to the callback
+            // appropriately.
+            //
+            context.process.on('close', function (code, signal) {
+                if (code === 127) {
+                    // XXX(sam) Not how node works (anymore?), 127 is what /bin/sh returns,
+                    // but it appears node does not, or not in all conditions, blithely
+                    // return 127 to user, it emits an 'error' from the child_process.
+
+                    //
+                    // If the response code is `127` then `context.command` was not found.
+                    //
+                    return onError(new Error('Command not found: ' + context.command));
+                }
+
+                if (context.queue.length && !flushQueue()) {
+                    // if flushQueue returned false, onError was called
+                    return;
+                }
+
+                callback(null, stdout, signal || code);
+            });
+
+            return context;
+        }
+    };
 }
 
 function spectcl (command, params, options) {
-  if (arguments.length === 2) {
-    if (Array.isArray(arguments[1])) {
-      options = {};
+    if (arguments.length === 2) {
+        if (Array.isArray(arguments[1])) {
+            options = {};
+        }
+        else {
+            options = arguments[1];
+            params = null;
+        }
     }
-    else {
-      options = arguments[1];
-      params = null;
+
+    if (Array.isArray(command)) {
+        params  = command;
+        command = params.shift();
     }
-  }
+    else if (typeof command === 'string') {
+        command = command.split(' ');
+        params  = params || command.slice(1);
+        command = command[0];
+    }
 
-  if (Array.isArray(command)) {
-    params  = command;
-    command = params.shift();
-  }
-  else if (typeof command === 'string') {
-    command = command.split(' ');
-    params  = params || command.slice(1);
-    command = command[0];
-  }
+    options = options || {};
+    context = {
+        command: command,
+        cwd: options.cwd || undefined,
+        env: options.env || undefined,
+        ignoreCase: options.ignoreCase,
+        params: params,
+        queue: [],
+        stream: options.stream || 'stdout',
+        stripColors: options.stripColors,
+        verbose: options.verbose
+    };
+    _emitter = new EventEmitter();
+    context._emitter = _emitter;
+    context.on = function(){
+        _emitter.on.apply(_emitter,arguments);
+    };
+    context.emit = function(){
+        _emitter.emit.apply(_emitter,arguments);
+    };
 
-  options = options || {};
-  context = {
-    command: command,
-    cwd: options.cwd || undefined,
-    env: options.env || undefined,
-    ignoreCase: options.ignoreCase,
-    params: params,
-    queue: [],
-    stream: options.stream || 'stdout',
-    stripColors: options.stripColors,
-    verbose: options.verbose
-  };
-  _emitter = new EventEmitter();
-  context._emitter = _emitter;
-  context.on = function(){
-    _emitter.on.apply(_emitter,arguments);
-  };
-  context.emit = function(){
-    _emitter.emit.apply(_emitter,arguments);
-  };
-
-  return chain(context);
+    return chain(context);
 }
 
 //
 // Export the core `spectcl` function as well as `nexpect.spectcl` for
 // backwards compatibility.
 //
-module.exports.spawn  = spectcl;
+module.exports.spawn    = spectcl;
+

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -359,11 +359,12 @@ function chain (context) {
 
 function spectcl (command, params, options) {
     if (arguments.length === 2) {
-        if (Array.isArray(arguments[1])) {
+        //Did we get a params array or an options object as the second parameter?
+        if (Array.isArray(params)) {
             options = {};
         }
         else {
-            options = arguments[1];
+            options = params;
             params = null;
         }
     }
@@ -379,7 +380,7 @@ function spectcl (command, params, options) {
     }
 
     options = options || {};
-    context = {
+    var context = {
         command: command,
         cwd: options.cwd || undefined,
         env: options.env || undefined,
@@ -390,7 +391,7 @@ function spectcl (command, params, options) {
         stripColors: options.stripColors,
         verbose: options.verbose
     };
-    _emitter = new EventEmitter();
+    var _emitter = new EventEmitter();
     context._emitter = _emitter;
     context.on = function(){
         _emitter.on.apply(_emitter,arguments);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "spectcl",
   "description": "Spawns and interacts with child processes using spawn / expect commands",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "Greg Cochard <greg@gregcochard.com>",
   "maintainers": [
-    "Greg Cochard <greg@gregcochard.com>"
+    "Greg Cochard <greg@gregcochard.com>",
+    "Ryan Milbourne <ryanbmilbourne@gmail.com>"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
There are few warnings that I'd like to highlight and get more comment on them:

- (line 128) empty catch in `onError` function.  
  - Catches exceptions thrown when the spawned process cannot be killed.  `process.kill` only throws when the process to kill doesn't exist, so this should be okay since `onError` indicates we've already had issues anyway.
- (line 362, 6) use of `arguments` object in `spectcl` function.  
  - It looks like it's being used to support use cases that involve passing only `params` or only `options`.  Direct access like this tends to be slow.  If we want to support multiple argument lengths, we should probably reference the second parameter directly rather than `arguments[1]`.
- (lines 393,4) are `context` and `_emitter` supposed to be declared globally?
  - It looks to me like they should be within scope of `spectcl` function and should have `var` used in their declaration so they’re local in scope.