### PR TITLE
smarter eslintrc exceptions (refs #3)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
     "env": {"node": true},
     "globals": {},
+    "extends": "eslint:recommended",
     "rules": {
       "no-extra-parens": 2,
       "no-unexpected-multiline": 2,
@@ -61,6 +62,6 @@
       "quotes": [2, "single", "avoid-escape"],
       "semi": [2, "never"],
       "space-return-throw-case": 2,
-      "spaced-comment": [2, "always", {"exceptions": ["="]}]
+      "spaced-comment": [2, "always", {"exceptions": ["=","-"], "markers":["eslint-disable","eslint-enable","eslint-disable-line","global"]}]
     }
 }

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -64,9 +64,9 @@ function chain (context) {
             var _wait = function _wait (data) {
                 var val = testExpectation(data, expectation)
                 if (val === true && typeof callback === 'function') {
-                    /* eslint-disable callback-return */
+                    /*eslint-disable callback-return */
                     callback(data)
-                    /* eslint-enable callback-return */
+                    /*eslint-enable callback-return */
                 }
                 return val
             }
@@ -128,7 +128,7 @@ function chain (context) {
 
                 if (kill) {
                     try { context.process.kill() }
-                    catch (ignore) { }
+                    catch (ignore) { } //eslint-disable-line no-empty
                 }
 
                 return callback(err)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "colors": "0.x.x",
     "coveralls": "^2.11.2",
     "dateformat": "^1.0.11",
-    "eslint": "^1.0.0-rc-1",
+    "eslint": "^1.0.0",
     "gh-got": "^1.1.0",
     "istanbul": "^0.3.14",
     "markdownlint": "0.0.5",

--- a/test/spectcl-test.js
+++ b/test/spectcl-test.js
@@ -9,7 +9,6 @@
 var assert = require('assert'),
     path = require('path'),
     vows = require('vows'),
-    spawn = require('child_process').spawn,
     spectcl = require('../lib/spectcl')
 
 function assertSpawn (expect) {
@@ -66,6 +65,7 @@ vows.describe('spectcl').addBatch({
                     child.run(function(err,stdout,exitcode){
                         assert.isTrue(!err)
                         assert.isArray(stdout)
+                        assert.equal(exitcode,0)
                     })
                     child.on('wait',function(data){
                         if(data === '>'){
@@ -81,7 +81,7 @@ vows.describe('spectcl').addBatch({
                 'when RegExp expectation is met': assertSpawn(
                     spectcl.spawn('echo', ['hello'])
                     .expect(/^hello$/)
-                ),
+                )
             },
             'and using the wait() method': {
                 'when assertions are met': assertSpawn(
@@ -105,7 +105,7 @@ vows.describe('spectcl').addBatch({
                 'when a callback is provided and output is matched': {
                     topic: function() {
                         var expect = spectcl.spawn(path.join(__dirname, 'fixtures', 'prompt-and-respond'))
-                          .wait('first', this.callback)
+                        expect.wait('first', this.callback)
                           .sendline('first-prompt')
                           .expect('first-prompt')
                           .wait('second')
@@ -114,6 +114,7 @@ vows.describe('spectcl').addBatch({
                     },
                     'should call callback': function(matchData, b) {
                         assert.ok(matchData.indexOf('first') > 0, "Found 'first' in output")
+                        assert.equal(b,undefined)
                     }
                 },
                 'when a callback is provided and output is not matched': {
@@ -124,7 +125,7 @@ vows.describe('spectcl').addBatch({
                             }
 
                         var expect = spectcl.spawn(path.join(__dirname, 'fixtures', 'prompt-and-respond'))
-                          .wait('first')
+                        expect.wait('first')
                           .sendline('first-prompt')
                           .expect('first-prompt')
                           .wait('second')
@@ -133,6 +134,7 @@ vows.describe('spectcl').addBatch({
                     },
                     'should not call callback': function(args, a) {
                         assert.equal(args.hasRunCallback, false, 'Should not have run callback')
+                        assert.ok(a)
                     }
                 }
             },


### PR DESCRIPTION
This fixes the previously missing `extends: "eslint:recommended"` in the `.eslintrc` file. It also adds markers for `eslint-*` directives in comments, so we don't have to space them.