### PR TITLE
Add pty wrappers for spawned sessions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,9 @@ sudo: false
 cache:
   directories:
     - node_modules
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "4"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs"
+  - "4"
 
 branches:
     except:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.2.0 - September 18 2015
+
+* Add support for pty sessions.
+
 v0.1.0 - September 14 2015
 
 * Rework of API to support more Expect-like syntax.

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -8,6 +8,7 @@
  */
 
 var spawn = require('child_process').spawn
+  , pty = require('child_pty')
   , AssertionError = require('assert').AssertionError
   , events = require('events')
   , util = require('util')
@@ -17,9 +18,6 @@ module.exports = function Spectcl(options){
     options = options || {}
     //Some private things
     var EXP_CONTINUE = 4
-    //var child
-    //  , cache = ''
-    //  , emitter = new events.EventEmitter()
 
     //Public things here
     return {
@@ -47,8 +45,10 @@ module.exports = function Spectcl(options){
          * @param {string|Array} command - The command to spawn.  If string, will be split on ' ' if params not provided.
          * @param {Array} [cmdParams] - Argv to pass to the child process.
          * @param {Object} [cmdOptions] - Options used when spawning the child.
+         * @param {Object} [spawnOptions] - Options used when spawning the child.
+         * @param {boolean} spawnOptions.noPty - If true, spectcl will spawn the child directly, without obtaining a pty session.
          */
-        spawn: function(command, cmdParams, cmdOptions){
+        spawn: function(command, cmdParams, cmdOptions, spawnOptions){
             var self = this
 
             /**
@@ -100,21 +100,39 @@ module.exports = function Spectcl(options){
                 command = command[0]
             }
 
-            self.child = spawn(command, cmdParams, cmdOptions)
-            debug('[spawn] '+self.child.pid)
+            spawnOptions = spawnOptions || {}
+            debug('[spawn] command:\t%s',       command)
+            debug('[spawn] cmdParams:\t%s',     util.inspect(cmdParams))
+            debug('[spawn] cmdOptions:\t%s',    util.inspect(cmdOptions))
+            debug('[spawn] spawnOptions:\t%s',  util.inspect(spawnOptions))
+
+            if(spawnOptions.noPty){
+                self.child = spawn(command, cmdParams, cmdOptions)
+            } else {
+                self.child = pty.spawn(command, cmdParams, cmdOptions)
+                self.child.stdout.resize({columns: 0, rows: 0})
+                debug('[spawn] child tty:\t'+self.child.stdout.ttyname)
+            }
+            debug('[spawn] child pid:\t'+self.child.pid)
 
             self.child.on('error', function(err){
                 debug('[spawn] child error: '+err)
                 self.emit('error', err)
             })
 
-            self.child.on('close', function(code, signal){
-                self.emit('close', code, signal)
+            self.child.on('exit', function(code, signal){
+                debug('[spawn] child exit. code: %s\tsignal: %s',code,signal)
+                self.emit('exit', code, signal)
             })
 
             //TCL Expect watches both stdout and stderr by default
             self.child.stdout.on('data', onData)
-            self.child.stderr.on('data', onData)
+
+            // child_pty does not make stderr avilable at this time.
+            if(spawnOptions.noPty){
+                self.child.stderr.on('data', onData)
+            }
+
             return
         },
 
@@ -279,7 +297,15 @@ module.exports = function Spectcl(options){
          * Useful when working with apps that use inquirer.
          */
         sendEof: function(){
-            this.child.stdin.destroy()
+            var self = this
+            //child_pty requires us to call kill() directly.
+            if(self.child.stdout.ttyname){
+                debug('[sendEof] kill pty')
+                self.child.kill()
+            } else {
+                debug('[sendEof] destroy sdtin')
+                self.child.stdin.destroy()
+            }
             return
         },
 
@@ -311,8 +337,8 @@ module.exports = function Spectcl(options){
          * Spectcl is an emitter.
          */
 
-        /* istanbul ignore next */
         removeListener: function(){
+            /* istanbul ignore next */
             return this.emitter.removeListener.apply(this.emitter, arguments)
         }
 

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -12,6 +12,7 @@ var spawn = require('child_process').spawn
   , AssertionError = require('assert').AssertionError
   , events = require('events')
   , util = require('util')
+  , extend = require('extend')
   , debug = require('debug')('spectcl')
 
 module.exports = function Spectcl(options){
@@ -109,8 +110,8 @@ module.exports = function Spectcl(options){
             if(spawnOptions.noPty){
                 self.child = spawn(command, cmdParams, cmdOptions)
             } else {
+                cmdOptions = extend({columns: 0, rows: 0}, cmdOptions)
                 self.child = pty.spawn(command, cmdParams, cmdOptions)
-                self.child.stdout.resize({columns: 0, rows: 0})
                 debug('[spawn] child tty:\t'+self.child.stdout.ttyname)
             }
             debug('[spawn] child pid:\t'+self.child.pid)

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "license": "MIT",
   "dependencies": {
     "child_pty": "^2.0.1",
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "extend": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Greg Cochard <greg@gregcochard.com>",
   "maintainers": [
     "Greg Cochard <greg@gregcochard.com>",
-    "Ryan Milbourne <ryanbmilbourne@gmail.com>"
+    "Ryan Milbourne <ryan.milbourne@viasat.com>"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spectcl",
   "description": "Spawns and interacts with child processes using spawn / expect commands",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Greg Cochard <greg@gregcochard.com>",
   "maintainers": [
     "Greg Cochard <greg@gregcochard.com>",
@@ -55,6 +55,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "child_pty": "^2.0.1",
     "debug": "^2.2.0"
   }
 }

--- a/test/spectcl.js
+++ b/test/spectcl.js
@@ -79,7 +79,7 @@ describe('spectcl', function(){
         it('should emit `data` event when child session sends data', function(done){
             var session = new spectcl()
             session.on('data', function(data){
-                assert.equal(data, 'hello\r\n')
+                assert.equal(/hello/.test(data), true, 'unexpected output: '+data)
                 done()
             })
             session.spawn('echo hello')


### PR DESCRIPTION
Note that pty will be used by default.  To spawn without a pty wrapper,
use `noPty: true` in the spawn options object.

This commit also updates tests to validate pty functionality.

Resolves: #16