### PR TITLE
Add `match` property to `expect_out`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
+v0.3.0 - September 24 2015
+
+* Add `expect_out.match` property. (Ryan Milbourne)
+* Docs: Add `ViaSat, Inc.` to License 2015 Copyright. (Ryan Milbourne)
+* Build: Fix `eslint` errors. (Ryan Milbourne)
+
+
 v0.2.0 - September 18 2015
 
-* Add support for pty sessions.
+* Add support for pty sessions. (Ryan Milbourne)
+
 
 v0.1.0 - September 14 2015
 
-* Rework of API to support more Expect-like syntax.
-* Build: Modify tests to use mocha. 
-* Build: Add `.istanbul.yml` with coverage thresholds.
-* Build: Write new tests that use the new control flow.
-* Docs: Update README.md.
+* Rework of API to support more Expect-like syntax. (Ryan Milbourne)
+* Build: Modify tests to use mocha. (Ryan Milbourne)
+* Build: Add `.istanbul.yml` with coverage thresholds. (Ryan Milbourne)
+* Build: Write new tests that use the new control flow. (Ryan Milbourne
+* Docs: Update README.md. (Ryan Milbourne)
 
 
 v0.0.7 - June 6, 2015

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 spectcl
 
-Copyright (c) 2015 Greg Cochard, Ryan Milbourne http://github.com/spectcl/spectcl
+Copyright (c) 2015 Greg Cochard, Ryan Milbourne, ViaSat, Inc. http://github.com/spectcl/spectcl
 Copyright (c) 2010 Elijah Insua, Marak Squires, Charlie Robbins  http://github.com/nodejitsu/nexpect
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -1,4 +1,3 @@
-'use strict'
 /*
  * spectcl.js: Top-level include for the `spectcl` module.
  *
@@ -7,20 +6,22 @@
  *
  */
 
+'use strict'
+
 var spawn = require('child_process').spawn
   , pty = require('child_pty')
-  , AssertionError = require('assert').AssertionError
   , events = require('events')
   , util = require('util')
   , extend = require('extend')
-  , debug = require('debug')('spectcl')
+
+var debug = require('debug')('spectcl')
 
 module.exports = function Spectcl(options){
     options = options || {}
-    //Some private things
+    // Some private things
     var EXP_CONTINUE = 4
 
-    //Public things here
+    // Public things here
     return {
         /**
          * Output object accessible by the user.
@@ -28,9 +29,11 @@ module.exports = function Spectcl(options){
          * This object is meant to emulate TCL Expect's expect_out behavior.
          * For more, see http://www.tcl.tk/man/expect5.31/expect.1.html
          */
+        /*eslint-disable camelcase */
         expect_out: {
             buffer: ''
         },
+        /*eslint-enable camelcase */
 
         options: options,
         emitter: new events.EventEmitter(),
@@ -38,7 +41,7 @@ module.exports = function Spectcl(options){
         child: null,
         expecting: false,
 
-        //Enum values for special handling
+        // Enum values for special handling
         EXP_CONTINUE:   4,
 
         /**
@@ -48,6 +51,7 @@ module.exports = function Spectcl(options){
          * @param {Object} [cmdOptions] - Options used when spawning the child.
          * @param {Object} [spawnOptions] - Options used when spawning the child.
          * @param {boolean} spawnOptions.noPty - If true, spectcl will spawn the child directly, without obtaining a pty session.
+         * @returns {undefined}
          */
         spawn: function(command, cmdParams, cmdOptions, spawnOptions){
             var self = this
@@ -57,8 +61,9 @@ module.exports = function Spectcl(options){
              * Evaluates the processed lines:
              * 1. Stripping ANSI colors (if necessary)
              * 2. Removing case sensitivity (if necessary)
-             * @params {String|Object} data - Data to process
+             * @param {String|Object} data - Data to process
              * @fires Spectcl#data
+             * @returns {undefined}
              */
             function onData(data) {
                 if(typeof data !== 'string'){
@@ -73,16 +78,18 @@ module.exports = function Spectcl(options){
                     data = data.toLowerCase()
                 }
 
-                //Append to the cache and emit the 'data' event.
-                //While it might be of value to users, the event primarily serves
-                //to notify expect statements when there is new data on the cache to scan
+                /**
+                 * Append to the cache and emit the 'data' event.
+                 * While it might be of value to users, the event primarily serves
+                 * to notify expect statements when there is new data on the cache to scan
+                 */
                 self.cache = self.cache.concat(data)
                 self.emit('data', data)
             }
 
-            //Arguments handling
+            // Arguments handling
             if (arguments.length === 2) {
-                //Did we get a params array or an options object as the second parameter?
+                // Did we get a params array or an options object as the second parameter?
                 if (Array.isArray(cmdParams)) {
                     cmdOptions = {}
                 }
@@ -102,10 +109,10 @@ module.exports = function Spectcl(options){
             }
 
             spawnOptions = spawnOptions || {}
-            debug('[spawn] command:\t%s',       command)
-            debug('[spawn] cmdParams:\t%s',     util.inspect(cmdParams))
-            debug('[spawn] cmdOptions:\t%s',    util.inspect(cmdOptions))
-            debug('[spawn] spawnOptions:\t%s',  util.inspect(spawnOptions))
+            debug('[spawn] command:\t%s', command)
+            debug('[spawn] cmdParams:\t%s', util.inspect(cmdParams))
+            debug('[spawn] cmdOptions:\t%s',util.inspect(cmdOptions))
+            debug('[spawn] spawnOptions:\t%s', util.inspect(spawnOptions))
 
             if(spawnOptions.noPty){
                 self.child = spawn(command, cmdParams, cmdOptions)
@@ -126,7 +133,7 @@ module.exports = function Spectcl(options){
                 self.emit('exit', code, signal)
             })
 
-            //TCL Expect watches both stdout and stderr by default
+            // TCL Expect watches both stdout and stderr by default
             self.child.stdout.on('data', onData)
 
             // child_pty does not make stderr avilable at this time.
@@ -139,7 +146,7 @@ module.exports = function Spectcl(options){
 
 
         /**
-         * Called after the expectation matches.  
+         * Called after the expectation matches.
          * @callback Spectcl~expectCallback
          * @param {string|Object} match - Contains results of RegExp match or String that matched expectation.
          * @returns {Number} Can optionally return Spectcl~CONTINUE, which will trigger exp_continue-like behavior.
@@ -147,14 +154,17 @@ module.exports = function Spectcl(options){
 
         /**
          * Wait until given pattern matches output of the spanwed process.
-         * @param {Array} expArr - An array of even length, of the form: [{RegExp|String}, {Function}, {RegExp|String}, {Function}, ... ] 
+         * @param {Array} expArr - An array of even length, of the form:
+         * [{RegExp|String}, {Function}, {RegExp|String}, {Function}, ... ]
          * @example
          * // Watch for a '#' prompt
-         * spectcl.expect([/#/, function(){ //called when we match on /#/ }])
+         * spectcl.expect([/#/, function(){ // called when we match on /#/ }])
+         * @return {Spectcl~expectCallback} Callback to handle the response
          */
         expect: function(expArr){
             var self = this
               , expectations = []
+              , expectation
               , expectObject = {}
               , expectCallbacks = expArr
 
@@ -166,50 +176,53 @@ module.exports = function Spectcl(options){
                  * @returns {String|RegExp|Number} The Expectation that was found in the cache or null if no match was found.
                  */
               , matchCache = function scanCache(){
-                    for(var i=0; i<expectations.length; i++){
-                        var exp = expectations[i]
-                        if(exp instanceof RegExp){
-                            var match = exp.exec(self.cache)
-                            if(!match){
-                                continue
-                            }
-                            //Flush *only* the contents up to and including the match to expect_out.buffer
-                            self.expect_out.buffer = self.cache.substring(0,match.index+match[0].length)
-                            self.cache = self.cache.substring(match.index+match[0].length)
-                            return expectations[i]
-                        } else {
-                            var matchIdx = self.cache.indexOf(expectation)
-                            if(matchIdx === -1){
-                                continue
-                            }
-                            //Flush *only* the contents up to and including the match to expect_out.buffer
-                            self.expect_out.buffer = self.cache.substring(0,matchIdx+expectation.length)
-                            self.cache = self.cache.substring(matchIdx+expectation.length)
-                            return expectations[i]
-                        }
-                    }
-                    return 
-                }
+                  for(var i=0; i<expectations.length; i++){
+                      var exp = expectations[i]
+                      if(exp instanceof RegExp){
+                          var match = exp.exec(self.cache)
+                          if(!match){
+                              continue
+                          }
+                          // Flush *only* the contents up to and including the match to expect_out.buffer
+                          self.expect_out.buffer = self.cache.substring(0,match.index+match[0].length)
+                          self.expect_out.match = match
+                          debug('expect_out: '+util.inspect(self.expect_out))
+                          self.cache = self.cache.substring(match.index+match[0].length)
+                      } else {
+                          var matchIdx = self.cache.indexOf(expectation)
+                          if(matchIdx === -1){
+                              continue
+                          }
+                          // Flush *only* the contents up to and including the match to expect_out.buffer
+                          self.expect_out.buffer = self.cache.substring(0,matchIdx+expectation.length)
+                          self.expect_out.match = expectation
+                          self.cache = self.cache.substring(matchIdx+expectation.length)
+                      }
+                      debug('expect_out: '+util.inspect(self.expect_out))
+                      return expectations[i]
+                  }
+              }
 
                 /**
                  * Called when we've found a match in the cache.
-                 * @params {String|RegExp|Number} the expectation on which we matched.
+                 * @param {String|RegExp|Number} matchedExpectation - the expectation on which we matched.
+                 * @return {undefined}
                  */
               , onMatch = function onMatch(matchedExpectation){
-                    //We matched in this block, so we're this expect block is considered complete.
-                    self.expecting = false
+                  // We matched in this block, so we're this expect block is considered complete.
+                  self.expecting = false
 
-                    var expectationCb = expectObject[matchedExpectation]
-                      , cbRetVal = expectationCb(matchedExpectation)
+                  var expectationCb = expectObject[matchedExpectation]
+                    , cbRetVal = expectationCb(matchedExpectation)
 
-                    if(cbRetVal === EXP_CONTINUE){
-                        //we are supposed to continue, so call expect again with this invokation's arguments
-                        debug('[expect] EXP_CONTINUE');
-                        self.expect(expectCallbacks)
-                    }
-                    //expectCallbacks = null
-                    return
-                }
+                  if(cbRetVal === EXP_CONTINUE){
+                      // We are supposed to continue, so call expect again with this invokation's arguments
+                      debug('[expect] EXP_CONTINUE')
+                      self.expect(expectCallbacks)
+                  }
+                  // expectCallbacks = null
+                  return
+              }
 
             if(!expectCallbacks.length){
                 self.emit('error', new Error('cannot call expect with empty array'))
@@ -228,14 +241,12 @@ module.exports = function Spectcl(options){
 
             self.expecting = true
 
-            //TODO: Add expect_after handling here
-
-            //For each expectation/callback pair, add to the current expects object.
+            // For each expectation/callback pair, add to the current expects object.
             for(var i=0; i<expectCallbacks.length; i+=2){
-                var expectation = expectCallbacks[i]
-                  , expCallback = expectCallbacks[i+1]
+                expectation = expectCallbacks[i]
+                var expCallback = expectCallbacks[i+1]
 
-                //Type checking of expectation/callback pairing
+                // Type checking of expectation/callback pairing
                 if(typeof expectation !== 'string' && !(expectation instanceof RegExp)){
                     self.emit('error', new Error('invalid exp (must be string or RegExp): '+expectation))
                     return
@@ -245,23 +256,19 @@ module.exports = function Spectcl(options){
                     return
                 }
 
-                //TODO: Add special spectcl.TIMEOUT|EOF|ETC enumerated types
-
                 expectations.push(expectation)
 
-                //We only care about the first callback we're given
+                // We only care about the first callback we're given
                 if(!expectObject[expectation]){
                     expectObject[expectation] = expCallback
                 }
             }
-            debug('[expect] expectations: '+Object.keys(expectObject));
+            debug('[expect] expectations: '+Object.keys(expectObject))
 
-            //TODO: Add expect_after handling here
-
-            //Do an initial scan of the cache looking for our match
+            // Do an initial scan of the cache looking for our match
             var match = matchCache()
             if(match){
-                debug('[expect] found match in cache');
+                debug('[expect] found match in cache')
                 onMatch(match)
                 return
             }
@@ -273,10 +280,10 @@ module.exports = function Spectcl(options){
                     onMatch(match)
                     return
                 }
-                self.once('data', dataCallback);
+                self.once('data', dataCallback)
             }
 
-            //No match found in the initial sweep of the cache, so scan on subsequent additions
+            // No match found in the initial sweep of the cache, so scan on subsequent additions
             self.once('data', dataCallback)
         },
 
@@ -284,9 +291,10 @@ module.exports = function Spectcl(options){
         /**
          * Sends data to the spawned process
          * @param {string} data - Data to send to the current spawned process.
+         * @return {undefined}
          */
         send: function(data){
-            debug('[send] writing to child stdin');
+            debug('[send] writing to child stdin')
             this.child.stdin.write(data, function(){
                 return
             })
@@ -296,10 +304,11 @@ module.exports = function Spectcl(options){
         /**
          * Destroy the spawned process' stdin stream.
          * Useful when working with apps that use inquirer.
+         * @return {undefined}
          */
         sendEof: function(){
             var self = this
-            //child_pty requires us to call kill() directly.
+            // child_pty requires us to call kill() directly.
             if(self.child.stdout.ttyname){
                 debug('[sendEof] kill pty')
                 self.child.kill()
@@ -313,6 +322,7 @@ module.exports = function Spectcl(options){
 
         /**
          * Spectcl is an emitter.
+         * @return {undefined}
          */
         on: function(){
             return this.emitter.on.apply(this.emitter, arguments)
@@ -321,6 +331,7 @@ module.exports = function Spectcl(options){
 
         /**
          * Spectcl is an emitter.
+         * @return {undefined}
          */
         once: function(){
             return this.emitter.once.apply(this.emitter, arguments)
@@ -329,6 +340,7 @@ module.exports = function Spectcl(options){
 
         /**
          * Spectcl is an emitter.
+         * @return {undefined}
          */
         emit: function(){
             return this.emitter.emit.apply(this.emitter, arguments)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spectcl",
   "description": "Spawns and interacts with child processes using spawn / expect commands",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Greg Cochard <greg@gregcochard.com>",
   "maintainers": [
     "Greg Cochard <greg@gregcochard.com>",


### PR DESCRIPTION
`match` is analogous to the expect_out pattern matches in TCL Expect.
Instead of expect_out.[0|1|n], we'll have a single `match` property that
will contain the string we matched on if the expectation was a String,
or the result object of the successful test if the expectation was a
RegExp. Glob support is planned as well.

Also add ViaSat, Inc. to the license copyright.

In addition, some `eslint` errors were added by me; `pre-git` was
uninstalled in my local mirror and I didn't notice, so my commits
were not being linted.
This commit fixes all `eslint` errors introduced.

Resolves #11
See also #18