### PR TITLE
Add support for `timeout` and `eof` expecatations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.4.0
+
+* Add support for `eof` and `timeout`
+* Docs: Update README with `Getting Started`
+
 v0.3.1 - September 26 2015
 
 * Docs: Update examples, add reference in README

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 is based on the ideas of the [Expect][0] library by Don Libes and the [pexpect][1]
 library by Noah Spurrier.
 
+**Note that this module is under initial development.
+The API is subject to change until we reach the 
+[v1.0.0 Milestone](https://github.com/spectcl/spectcl/milestones/v1.0.0).**
+
 ## Motivation
 
 Node.js has good built in control for spawning child processes. `nexpect` built on
@@ -12,7 +16,7 @@ those methods that allowed developers to easily pipe data to child processes and
 assert the expected response.
 
 `spectl` stands on the shoulders of `nexpect`; one of this module's main goals is
-to more closely emulate the Expect extensions built into the TCL language. Its
+to more closely emulate the Expect extensions built into the Tcl language. Its
 concentration is to map the functionality and features of the [Expect][0] library
 as closely as possible, while adhering to an event-driven control flow.
 
@@ -25,30 +29,34 @@ as closely as possible, while adhering to an event-driven control flow.
 ## Usage
 
 ``` js
-var spectcl = require('spectcl')
-  , session = new spectcl()
+var Spectcl = require('spectcl')
+  , session = new Spectcl()
 
 session.spawn('node --interactive')
 session.expect([
-    '>', function(){
+    '>', function(match, cb){
         session.send('process.version\n')
-        session.expect([
-            '>', function(){
-                session.send('process.exit()\n')
-                var version = session.expect_out.buffer.match(/(v[0-9]\.[0-9]+\.[0-9]+)/)[1]
-                console.log('version is: %s', version)
-            }
-        ]}
+        cb()
     }
-])
+], function(err){
+    session.expect([
+        '>', function(match, cb){
+            session.send('process.exit()\n')
+            cb()
+        }
+    ], function(err){
+        var version = session.expect_out.buffer.match(/(v[0-9]\.[0-9]+\.[0-9]+)/)[1]
+        console.log('version is: %s', version)
+    })
+})
 ```
 
-Usage is similar to Expect, but not identical.  
-In the example above, we spawn a `node` interactive interpreter, 
-have it output the value of `process.version`, 
-capture the results from the expect_out buffer, and close the session, printing the version.
+In the example above, we spawn a `node` interactive interpreter, have it output the
+value of `process.version`, and send `process.exit()`.  We capture the results from
+the expect_out buffer, and close the session, printing the version in the final
+callback.
 
-Compare to this TCL Expect block:
+Compare to this Tcl Expect block:
 
 ``` tcl
 package require Expect
@@ -61,14 +69,107 @@ expect ">" {
 }
 expect ">" {
     exp_send "process.exit()\n"
-    regexp {(v[0-9]\.[0-9]+\.[0-9]+)} $expect_out(buffer) -> version
-    puts "version is: $version"
 }
+regexp {(v[0-9]\.[0-9]+\.[0-9]+)} $expect_out(buffer) -> version
+puts "version is: $version"
 ```
+
+## Getting Started
+
+```js
+var session = new Spectcl()
+```
+
+A spectcl object exposes two main functions: spawn and expect.  A Spectcl object is intended to only have
+one spawned child at a time.  To operate concurrently on many sessions, you will need to spawn an object
+for each concurrent session.
+
+### spawn()
+
+This function is used to spawn the child session that you'll be expecting on.  Note that like Tcl Expect,
+by default your child will be wrapped in a pseudoterminal. Some sessions, like Telnet, are not sensitive
+to having a pty, and as such can be spawned without a pty if desired.  You can do that like so:
+
+```js
+session.spawn('echo', ['hello'], {}, {noPty: true})
+```
+
+The Spectcl object will emit `exit` when the child is complete, and `error` if there is an issue spawning
+the child.
+
+### expect()
+
+This function will wait for data from the stream to match one of the expectations you specify.
+It takes an array and a final callback, structured like so:
+
+```js
+session.expect([
+    'hello', function(){
+        // handle hello here
+        cb()
+    }
+], function(){
+    console.log('all done!')
+})
+```
+
+The array needs to be even in length.  The even indices are your "expectations".  These can be of type
+String or Regexp, and are things that you want to match on.  The odd indices will be the handler functions
+for the expectation that precedes it.  In the example above, we are going to match on `/hello/`.  When we
+do, the handler function is called.  
+
+The handler functions will be called with the match object (Either a String or the Match object from the
+RegExp test), and the final callback.
+
+Like Tcl Expect, `expect()` will wait until a match occurs, a specified period of time has elapsed,
+or EOF is seen.  The timeout period can be specified when creating the Spectcl object by specifying a
+timeout property in the options object.  The default period is 30s.  
+
+This specifies the timeout period, in ms:
+```js
+var session = new Spectcl({timeout: 5000})
+```
+
+...and you can expect TIMEOUT or EOF like so:
+
+```js
+session.expect([
+    session.TIMEOUT, function(match, cb){
+        cb(new Error('timeout'))
+    },
+    session.EOF, function(match, cb){
+        cb(new Error('eof'))
+    }
+], function(err){
+    if(err){ console.log(err) }
+})
+``` 
+
+In the above sample, we are expecting to see either a TIMEOUT or an EOF, and can handle it appropriately.
+It is important to note that if you do not expect TIMEOUT or EOF and one occurs, the final callback will
+be called, with no Error:
+
+```js
+session.expect([
+    /foo/, function(match, cb){
+        // do things
+        cb()
+    }
+], function(err){
+    if(err){ console.log(err) }
+})
+``` 
+
+In the above example, if the session is ended abruptly or if it is inactive for the specified period of
+time, then the final callback will be called directly, since no handler was specified for either case.
+
+This design mirrors Tcl Expect's `expect` procedure, which returns immediately for these cases if they
+are not expected.
 
 ## Examples
 
-The [examples](examples) directory contains spectcl code examples, as well as their TCL Expect equivalents.
+The [examples](examples) directory contains spectcl code examples, as well as their Tcl Expect equivalents.
+
 
 ## API Reference
 

--- a/examples/eof.js
+++ b/examples/eof.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /*
- * echo.js: Simple example for using the `echo` command with spectcl.
+ * eof.js: Simple example for expecting eof.
  *
  * (C) 2015, Greg Cochard, Ryan Milbourne, ViaSat Inc.
  * (C) 2011, Elijah Insua, Marak Squires, Charlie Robbins.
@@ -12,12 +12,15 @@ var Spectcl = require('../lib/spectcl')
 
 var session = new Spectcl({timeout: 5000})
 
-session.spawn('echo', ['hello'])
+session.spawn('echo hello', [], {}, {noPty:true})
 session.expect([
-    /hello/, function(match, cb){
-            console.log('hello was echoed')
-            cb()
+    /goodbye/, function(match, cb){
+        console.log('goodbye was echoed')
+        cb()
     },
+    session.EOF, function(match, cb){
+        cb('eof')
+    }
 ], function(err){
     if(err){
         console.log('exp error: %s',err)

--- a/examples/ignoreCase.js
+++ b/examples/ignoreCase.js
@@ -14,7 +14,10 @@ var session = new Spectcl()
 
 session.spawn('echo', ['hElLo'])
 session.expect([
-    /hello/i, function(){
+    /hello/i, function(match, cb){
         console.log('hello was echoed')
+        cb()
     }
-]);
+], function(){
+    console.log('all done')
+})

--- a/examples/ls-la.js
+++ b/examples/ls-la.js
@@ -13,7 +13,12 @@ var session = new Spectcl()
 
 session.spawn('ls -la /tmp/undefined', { stream: 'stderr' })
 session.expect([
-    'No such file or directory', function(){
-        console.log('That file/dir doesn\'t exist!')
+    'No such file or directory', function(match, cb){
+        cb(new Error('That file/dir doesn\'t exist!'))
     }
-])
+], function(err){
+    if(err){
+        console.log(err)
+    }
+    console.log('all done')
+})

--- a/examples/nested.js
+++ b/examples/nested.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/*
+ * nested.js: Simple example showing use of nested expect calls with callbacks.
+ *     Note that as with the TCL equivelent, this is a bit of an anti-pattern.
+ *            
+ *
+ * (C) 2015, Ryan Milbourne, ViaSat Inc.
+ *
+ */
+
+var Spectcl = require('../lib/spectcl')
+
+var session = new Spectcl()
+
+session.spawn('node --interactive')
+session.expect([
+    />/, function(match, outer_cb){
+        session.send('console.log(\'testing\')\r')
+        session.expect([
+            '>', function(match, inner_cb){
+                session.send('process.exit()\r')
+                inner_cb()
+            }
+        ], function(err){
+            console.log('output was:\n%s',session.expect_out.buffer)
+            outer_cb()
+        })
+    }
+], function(err){
+    console.log('all done')
+})

--- a/examples/node.js
+++ b/examples/node.js
@@ -17,13 +17,18 @@ session.on('exit', function(){
 
 session.spawn('node --interactive')
 session.expect([
-    />/, function(){
+    />/, function(match, cb){
         session.send('console.log(\'testing\')\r')
-        session.expect([
-            '>', function(){
-                session.send('process.exit()\r')
-                console.log('output was:\n%s',session.expect_out.buffer)
-            }
-        ])
+        cb()
     }
-])
+], function(){
+    session.expect([
+        '>', function(match, cb){
+            session.send('process.exit()\r')
+            console.log('output was:\n%s',session.expect_out.buffer)
+            cb()
+        }
+    ], function(err){
+        console.log('all done')
+    })
+})

--- a/examples/timeout.js
+++ b/examples/timeout.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
 /*
- * echo.js: Simple example for using the `echo` command with spectcl.
+ * timeout.js: Simple example for expecting a timeout.
  *
  * (C) 2015, Greg Cochard, Ryan Milbourne, ViaSat Inc.
- * (C) 2011, Elijah Insua, Marak Squires, Charlie Robbins.
  *
  */
 
@@ -12,12 +11,17 @@ var Spectcl = require('../lib/spectcl')
 
 var session = new Spectcl({timeout: 5000})
 
-session.spawn('echo', ['hello'])
+session.spawn('node --interactive')
 session.expect([
-    /hello/, function(match, cb){
-            console.log('hello was echoed')
+    /foo/, function(match, cb){
+            console.log('foo was echoed')
+            //we'll never get here!
             cb()
     },
+    session.TIMEOUT, function(match, cb){
+        session.send('exit\r')
+        cb('timeout')
+    }
 ], function(err){
     if(err){
         console.log('exp error: %s',err)

--- a/examples/timeout.tcl
+++ b/examples/timeout.tcl
@@ -1,0 +1,24 @@
+#!/usr/bin/env tclsh
+
+# timeout.tcl: Simple example for expecting a timeout
+#
+# (C) 2015, Ryan Milbourne, ViaSat Inc.
+
+package require Expect
+log_user 0
+set timeout 5
+set ERROR ""
+
+spawn node "--interactive"
+expect {
+    "foo" {
+        puts "foo was echoed"
+    }
+    timeout {
+        exp_send "exit\r"
+        set ERROR "timeout"
+    }
+}
+if { $ERROR ne ""} {
+    puts "exp error: $ERROR"
+}

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -1,5 +1,4 @@
-/*
- * spectcl.js: Top-level include for the `spectcl` module.
+/* * spectcl.js: Top-level include for the `spectcl` module.
  *
  * (C) 2015, Greg Cochard, Ryan Milbourne
  * (C) 2011, Elijah Insua, Marak Squires, Charlie Robbins.
@@ -11,6 +10,7 @@
 var spawn = require('child_process').spawn
   , pty = require('child_pty')
   , events = require('events')
+  , through = require('through')
   , util = require('util')
   , extend = require('extend')
 
@@ -18,8 +18,8 @@ var debug = require('debug')('spectcl')
 
 module.exports = function Spectcl(options){
     options = options || {}
-    // Some private things
-    var EXP_CONTINUE = 4
+    options.timeout = options.timeout || 30000
+    options.matchMax = options.matchMax || 2000
 
     // Public things here
     return {
@@ -35,14 +35,55 @@ module.exports = function Spectcl(options){
         },
         /*eslint-enable camelcase */
 
+        /**
+         * Options object.
+         * @property {number} timeout - Max inactivity time, in ms. Defaults to 30s
+         * @property {number} matchMax - Max length of cache. Default to 2000
+         */
         options: options,
+
+        /**
+         * Spectcl is an emitter.
+         */
         emitter: new events.EventEmitter(),
+
+        /**
+         * String containing the data to match against thus far.
+         * Subject to matchMax restrictions.
+         * Once a match is found, the contents up to the match are flushed to
+         * expect_out.buffer.
+         */
         cache: '',
+
+        /**
+         * A buffering stream.  STDOUT/ERR is piped to this stream.
+         * Starts out paused, and is resumed when we are expecting, and is
+         * paused again when we match.  We also watch this stream for eof.
+         */
+        cacheStream: null,
+
+        /**
+         * Child object.
+         */
         child: null,
+
+        /**
+         * True if this session is currently in an expect block.
+         */
         expecting: false,
 
-        // Enum values for special handling
-        EXP_CONTINUE:   4,
+        /**
+         * Set when the cache string is longer than options.matchMax
+         */
+        fullBuffer: false,
+
+        /**
+         * Enum values for special handling
+         */
+        EXP_CONTINUE: 'EXP_CONTINUE\u1f4aa',
+        TIMEOUT: 'EXP_TIMEOUT\u1f4a9',
+        EOF: 'EXP_EOF\u1f4a5',
+        FULL_BUFFER: 'FULL_BUFFER\u1f355',
 
         /**
          * Spawns the Expect session's child process
@@ -84,6 +125,12 @@ module.exports = function Spectcl(options){
                  * to notify expect statements when there is new data on the cache to scan
                  */
                 self.cache = self.cache.concat(data)
+                if(self.cache.length > self.options.matchMax){
+                    // Naive implementation of matchMax.  Anything after matchMax is lost.
+                    // This feature will be fully fleshed out and is documented in #25.
+                    self.fullBuffer = true
+                    self.cache = self.cache.slice(self.cache.length-self.options.matchMax, self.cache.length)
+                }
                 self.emit('data', data)
             }
 
@@ -114,13 +161,35 @@ module.exports = function Spectcl(options){
             debug('[spawn] cmdOptions:\t%s',util.inspect(cmdOptions))
             debug('[spawn] spawnOptions:\t%s', util.inspect(spawnOptions))
 
+            self.cacheStream = through(function(sessionData){
+                this.queue(sessionData)
+            }, function(){
+                this.queue(null)
+            })
+
+            self.cacheStream.pause()
+            debug('[spawn] created cacheStream')
+
+            // At present, child-pty does not expose a stderr stream
             if(spawnOptions.noPty){
                 self.child = spawn(command, cmdParams, cmdOptions)
+                self.child.stdout.pipe(self.cacheStream)
+                self.child.stderr.pipe(self.cacheStream)
             } else {
                 cmdOptions = extend({columns: 0, rows: 0}, cmdOptions)
                 self.child = pty.spawn(command, cmdParams, cmdOptions)
+                self.child.stdout.pipe(self.cacheStream)
+                /**
+                 * `child-pty` stdout/in streams do not emit `end` or `close`.
+                 * Watch for child to `close` (stdio streams terminated), and
+                 * queue an end event onto the cache stream.
+                 */
+                self.child.on('close', function(){
+                    self.cacheStream.end()
+                })
                 debug('[spawn] child tty:\t'+self.child.stdout.ttyname)
             }
+
             debug('[spawn] child pid:\t'+self.child.pid)
 
             self.child.on('error', function(err){
@@ -133,13 +202,7 @@ module.exports = function Spectcl(options){
                 self.emit('exit', code, signal)
             })
 
-            // TCL Expect watches both stdout and stderr by default
-            self.child.stdout.on('data', onData)
-
-            // child_pty does not make stderr avilable at this time.
-            if(spawnOptions.noPty){
-                self.child.stderr.on('data', onData)
-            }
+            self.cacheStream.on('data', onData)
 
             return
         },
@@ -147,26 +210,44 @@ module.exports = function Spectcl(options){
 
         /**
          * Called after the expectation matches.
-         * @callback Spectcl~expectCallback
+         * @callback Spectcl~expectHandlerCallback
          * @param {string|Object} match - Contains results of RegExp match or String that matched expectation.
-         * @returns {Number} Can optionally return Spectcl~CONTINUE, which will trigger exp_continue-like behavior.
+         * @params {Function} cb - `cb`
+         * @returns {String} Can optionally return Spectcl~EXP_CONTINUE, which will trigger exp_continue-like behavior.
          */
 
         /**
-         * Wait until given pattern matches output of the spanwed process.
+         * Called once a condition is met, or after a match handler is called.
+         * @callback Spectcl~expectFinalCallback
+         * @param {Object} err - Error object or null
+         */
+
+        /**
+         * Wait until:
+         * 1. One of the patterns matches the output of the spawned process
+         * 2. A specified time period has passed
+         * 3. End-of-file is seen
+         * After one of the above conditions is met, the provided callback will be called.
          * @param {Array} expArr - An array of even length, of the form:
-         * [{RegExp|String}, {Function}, {RegExp|String}, {Function}, ... ]
+         * [{RegExp|String}, {Spectcl~handlerCallback}, {RegExp|String}, {Spectcl~handlerCallback}, ... ]
+         * @param {Spectcl~expectFinalCallback} cb - Callback to handle the response
          * @example
          * // Watch for a '#' prompt
          * spectcl.expect([/#/, function(){ // called when we match on /#/ }])
-         * @return {Spectcl~expectCallback} Callback to handle the response
+         * @return {undefined}
          */
-        expect: function(expArr){
+        expect: function(expArr, cb){
             var self = this
               , expectations = []
               , expectation
               , expectObject = {}
               , expectCallbacks = expArr
+              , finalCb = cb || function(){}
+              , onEof // function to handle `end` event
+              , onTimeout // function to handle timeout case
+              , expTimeout // Timeout object
+              , dataCallback // Called when we have fresh data from the cache stream
+              , match
 
                 /**
                  * Scans the cache for a match from the expectation list and handles is appropriately.
@@ -175,27 +256,48 @@ module.exports = function Spectcl(options){
                  * Called once ~expectObject and ~expectCallbacks are populated from the arguments array.
                  * @returns {String|RegExp|Number} The Expectation that was found in the cache or null if no match was found.
                  */
-              , matchCache = function scanCache(){
+              , matchCache = function(){
                   for(var i=0; i<expectations.length; i++){
                       var exp = expectations[i]
+                        , matched
+                      if(exp === self.FULL_BUFFER && self.fullBuffer){
+                          self.expect_out.buffer = self.cache
+                          self.cache = ''
+                          self.fullBuffer = false
+                          matched = self.expect_out.buffer
+                          debug('[expect] match FULL_BUFFER')
+                          return expectations[i]
+                      }
                       if(exp instanceof RegExp){
-                          var match = exp.exec(self.cache)
-                          if(!match){
+                          matched = exp.exec(self.cache)
+                          if(!matched){
+                              debug('[expect] does input match on RegExp pattern "%s"? no', exp)
                               continue
                           }
+                          // We matched, so we need to start the stream buffering again and remove the eof listener.
+                          self.cacheStream.pause()
+                          self.cacheStream.removeListener('end', onEof)
+                          debug('[expect] does input match on RegExp pattern "%s"? yes', exp)
                           // Flush *only* the contents up to and including the match to expect_out.buffer
-                          self.expect_out.buffer = self.cache.substring(0,match.index+match[0].length)
-                          self.expect_out.match = match
-                          self.cache = self.cache.substring(match.index+match[0].length)
+                          self.expect_out.buffer = self.cache.substring(0,matched.index+matched[0].length)
+                          self.expect_out.match = matched
+                          self.cache = self.cache.substring(matched.index+matched[0].length)
+                          self.fullBuffer = false
                       } else {
                           var matchIdx = self.cache.indexOf(expectation)
                           if(matchIdx === -1){
+                              debug('[expect] does input match on string "%s"? no',exp)
                               continue
                           }
+                          // We matched, so we need to start the stream buffering again and remove the eof listener.
+                          self.cacheStream.pause()
+                          self.cacheStream.removeListener('end', onEof)
+                          debug('[expect] does input match on string "%s"? yes',exp)
                           // Flush *only* the contents up to and including the match to expect_out.buffer
                           self.expect_out.buffer = self.cache.substring(0,matchIdx+expectation.length)
                           self.expect_out.match = expectation
                           self.cache = self.cache.substring(matchIdx+expectation.length)
+                          self.fullBuffer = false
                       }
                       return expectations[i]
                   }
@@ -203,7 +305,14 @@ module.exports = function Spectcl(options){
 
                 /**
                  * Called when we've found a match in the cache.
-                 * @param {String|RegExp|Number} matchedExpectation - the expectation on which we matched.
+                 * If there's a handler for the given expectation, then call it.
+                 * If not, call the final callback.  Note that the handler can return
+                 * `EXP_CONTINUE`, which will trigger this expect to be immediately.
+                 * called again.  The handler can choose to call the final callback
+                 * If no handler exists for the matched expectation, then the final
+                 * callback will be called.
+                 *
+                 * @param {String|RegExp} matchedExpectation - the expectation on which we matched.
                  * @return {undefined}
                  */
               , onMatch = function onMatch(matchedExpectation){
@@ -211,30 +320,38 @@ module.exports = function Spectcl(options){
                   self.expecting = false
 
                   var expectationCb = expectObject[matchedExpectation]
-                    , cbRetVal = expectationCb(matchedExpectation)
+                    , cbRetVal
 
-                  debug('[expect] expect_out:\n'+util.inspect(self.expect_out))
-                  if(cbRetVal === EXP_CONTINUE){
+                  if(expectationCb){
+                      debug('[expect] calling handler for %s', matchedExpectation)
+                      cbRetVal = expectationCb(matchedExpectation, finalCb)
+                  } else{
+                      debug('[expect] warning: no callback defined for %s',matchedExpectation)
+                      return finalCb(null)
+                  }
+
+                  if(cbRetVal === self.EXP_CONTINUE){
                       // We are supposed to continue, so call expect again with this invokation's arguments
                       debug('[expect] EXP_CONTINUE')
-                      self.expect(expectCallbacks)
+                      return self.expect(expectCallbacks, finalCb)
                   }
-                  // expectCallbacks = null
-                  return
               }
 
             if(!expectCallbacks.length){
-                self.emit('error', new Error('cannot call expect with empty array'))
+                var err = new Error('cannot call expect with empty array')
+                self.emit('error', err)
                 return
             }
 
             if(expectCallbacks.length % 2){
-                self.emit('error', new Error('cannot call expect with array that is odd in length'))
+                err = new Error('cannot call expect with array that is odd in length')
+                self.emit('error', err)
                 return
             }
 
             if(self.expecting){
-                self.emit('error', new Error('Only one Expect block can be evaluated at a time'))
+                err = new Error('Only one Expect block can be evaluated at a time')
+                self.emit('error', err)
                 return
             }
 
@@ -247,11 +364,13 @@ module.exports = function Spectcl(options){
 
                 // Type checking of expectation/callback pairing
                 if(typeof expectation !== 'string' && !(expectation instanceof RegExp)){
-                    self.emit('error', new Error('invalid exp (must be string or RegExp): '+expectation))
+                    err = new Error('invalid exp (must be string or RegExp): '+expectation)
+                    self.emit('error', err)
                     return
                 }
                 if(typeof expCallback !== 'function'){
-                    self.emit('error', new Error('received non-function as expect callback'))
+                    err = new Error('received non-function as expect callback')
+                    self.emit('error', err)
                     return
                 }
 
@@ -264,26 +383,70 @@ module.exports = function Spectcl(options){
             }
             debug('[expect] expectations: '+Object.keys(expectObject))
 
-            // Do an initial scan of the cache looking for our match
-            var match = matchCache()
-            if(match){
-                debug('[expect] found match in cache')
-                onMatch(match)
-                return
+            /**
+             * Handles end of readable stream.
+             * Remove the data listener and clear the timeout interval.
+             * We do this to guarantee that EOF is what is matched.
+             * @private
+             * @returns {undefined}
+             */
+            onEof = function(){
+                clearInterval(expTimeout)
+                self.removeListener('data', dataCallback)
+                debug('[expect] read eof')
+                onMatch(self.EOF)
             }
 
-            function dataCallback(){
+
+            /**
+             * Handles timeout case.
+             * Remove teh data and eof listeners.
+             * We do this to guarantee that TIMEOUT is what is matched.
+             * @private
+             * @returns {undefined}
+             */
+            onTimeout = function(){
+                self.removeListener('data', dataCallback)
+                self.cacheStream.removeListener('end', onEof)
+                debug('[expect] timeout')
+                onMatch(self.TIMEOUT)
+            }
+
+            /**
+             * Scan the data for a match and handle accordingly.
+             * Called when we get fresh data from the child.
+             * If a match is found, remove the eof listener
+             * If a match is not found, we reset the timeout
+             * @private
+             * @returns {undefined}
+             */
+            dataCallback = function(){
+                if(expTimeout){
+                    // Found data, so clear the timeout
+                    clearTimeout(expTimeout)
+                }
                 match = matchCache()
                 if(match){
                     debug('[expect] found match in data')
                     onMatch(match)
                     return
                 }
+                expTimeout = setTimeout(onTimeout, self.options.timeout)
                 self.once('data', dataCallback)
             }
 
-            // No match found in the initial sweep of the cache, so scan on subsequent additions
-            self.once('data', dataCallback)
+            match = matchCache()
+            if(match){
+                // Match found in initial cache.  Remove eof listener and handle the match.
+                debug('[expect] found match in cache')
+                onMatch(match)
+            } else {
+                // No match found in the initial sweep of the cache, so scan on subsequent additions
+                expTimeout = setTimeout(onTimeout, self.options.timeout)
+                self.cacheStream.once('end', onEof)
+                self.once('data', dataCallback)
+                self.cacheStream.resume()
+            }
         },
 
 
@@ -347,8 +510,8 @@ module.exports = function Spectcl(options){
 
         /**
          * Spectcl is an emitter.
+         * @return {undefined}
          */
-
         removeListener: function(){
             /* istanbul ignore next */
             return this.emitter.removeListener.apply(this.emitter, arguments)
@@ -366,6 +529,14 @@ module.exports = function Spectcl(options){
          * @event Spectcl#error
          * @type {object}
          * @property {Object} err - Error object created during a spectcl session
+         */
+
+        /**
+         * Exit event.
+         * @event Spectcl#exit
+         * @type {object}
+         * @property {Number} code - exit code of child session's PID
+         * @property {String} signal - exit signal of child session's PID
          */
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spectcl",
   "description": "Spawns and interacts with child processes using spawn / expect commands",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Greg Cochard <greg@gregcochard.com>",
   "maintainers": [
     "Greg Cochard <greg@gregcochard.com>",
@@ -57,6 +57,7 @@
   "dependencies": {
     "child_pty": "^2.0.1",
     "debug": "^2.2.0",
-    "extend": "^3.0.0"
+    "extend": "^3.0.0",
+    "through": "^2.3.8"
   }
 }


### PR DESCRIPTION
This commit will allow users to expect timeout and eof on the session.
Also added is a 'final' callback for the expect function, which is
called from a handler function or on *unhandled* EOF/TIMEOUT.

In order to properly support this, a new stream is added that, when
paused, caches its messages to a buffer.  STDOUT/ERR is piped to this
stream, which is paused when we're not actively expecting.

Updates tests to account for new functionality.

In addition, this commit will add a "Getting Started" section to the
README that better explains how to get started with spectcl.

Comments and minor code cleanup also included.

Resolves #15