### PR TITLE
Fix eof listener not being removed on FULL_BUFFER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
-v0.4.0
+v0.4.1 - October 9 2015
 
-* Add support for `eof` and `timeout`
-* Docs: Update README with `Getting Started`
+* Fix #30 (Ryan Milbourne)
+
+v0.4.0 - October 7 2015
+
+* Add support for `eof` and `timeout` (Ryan Milbourne)
+* Docs: Update README with `Getting Started` (Ryan Milbourne)
 
 v0.3.1 - September 26 2015
 
-* Docs: Update examples, add reference in README
+* Docs: Update examples, add reference in README (Ryan Milbourne)
 
 
 v0.3.0 - September 24 2015

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -261,6 +261,8 @@ module.exports = function Spectcl(options){
                       var exp = expectations[i]
                         , matched
                       if(exp === self.FULL_BUFFER && self.fullBuffer){
+                          self.cacheStream.pause()
+                          self.cacheStream.removeListener('end', onEof)
                           self.expect_out.buffer = self.cache
                           self.cache = ''
                           self.fullBuffer = false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spectcl",
   "description": "Spawns and interacts with child processes using spawn / expect commands",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Greg Cochard <greg@gregcochard.com>",
   "maintainers": [
     "Greg Cochard <greg@gregcochard.com>",


### PR DESCRIPTION
The `eof` listener was not being removed and the cache stream was not
being paused when full_buffer occured and user was expecting it.  As a
result, the final callback for the expect invocation was potentially
being called twice.

Resolves #30