### PR TITLE
Fix npm install on node v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ branches:
         - gh-pages
         - /^v\d+(\.\d+){2}/
 
+before_install:
+    - npm i -g npm
+
 after_script:
     - if [[ `node --version` == *v0.10* ]]; then cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js; fi
 


### PR DESCRIPTION
This will update npm before travis attempts to run npm install. This solves a race condition in npm v2 (shipped with node v4) by updating to npm v3.