### PR TITLE
Add `debug` output to `npm test`, update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
+v0.4.2 - October 17 2015
+
+* Build: Add `debug` output to `test` script (Ryan Milbourne)
+* Build: Update dependencies (greenkeeper)
+* Build: Fix npm install on node v4 (Greg Cochard)
+
+
 v0.4.1 - October 9 2015
 
 * Fix #30 (Ryan Milbourne)
+
 
 v0.4.0 - October 7 2015
 
 * Add support for `eof` and `timeout` (Ryan Milbourne)
 * Docs: Update README with `Getting Started` (Ryan Milbourne)
+
 
 v0.3.1 - September 26 2015
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spectcl",
   "description": "Spawns and interacts with child processes using spawn / expect commands",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": "Greg Cochard <greg@gregcochard.com>",
   "maintainers": [
     "Greg Cochard <greg@gregcochard.com>",
@@ -37,7 +37,7 @@
   },
   "main": "./lib/spectcl",
   "scripts": {
-    "test": "istanbul cover node_modules/mocha/bin/_mocha",
+    "test": "DEBUG=spectcl istanbul cover node_modules/mocha/bin/_mocha",
     "lint": "eslint lib/*.js test/*.js"
   },
   "pre-commit": [


### PR DESCRIPTION
We're seeing intermittent errors in builds on Travis CI that are not
easy to replicate locally, either on the hardware OS or within a
container.  Add debug output could potentially give us better insight
into what is causing the failures on the Travis builds.