### PR TITLE
Add jsdoc2md

### DIFF
--- a/docugen.sh
+++ b/docugen.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo '---' > ../spectcl.github.io/api.md
+echo >> ../spectcl.github.io/api.md
+echo '---' >> ../spectcl.github.io/api.md
+echo >> ../spectcl.github.io/api.md
+jsdoc2md lib/*.js >> ../spectcl.github.io/api.md

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^1.0.0",
     "gh-got": "^2.0.1",
     "istanbul": "^0.3.14",
+    "jsdoc-to-markdown": "^1.2.0",
     "markdownlint": "0.0.8",
     "mocha": "^2.3.3",
     "npm-license": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "main": "./lib/spectcl",
   "scripts": {
     "test": "DEBUG=spectcl istanbul cover node_modules/mocha/bin/_mocha",
-    "lint": "eslint lib/*.js test/*.js"
+    "lint": "eslint lib/*.js test/*.js",
+    "docugen": "./docugen.sh"
   },
   "pre-commit": [
     "npm run lint"


### PR DESCRIPTION
This adds the `jsdoc2md` workflow to write to the `api.md` file in the sibling `spectcl.github.io` directory. This is making a lot of assumptions and I could use some bikeshedding on what to do here. How should we structure it, etc.