### PR TITLE
Add callbacks to send and sendEof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v0.4.3 - November 24 2015
+
+* Add callbacks to `send` and `sendEof` to support "fire and forget" use (Ryan Milbourne)
+* Build: Update dependencies (greenkeeper)
+* Docs: Update spectcl.github.io via `docugen` (Ryan Milbourne)
+* Docs: Add link to github.io API docs in README.md (Ryan Milbourne)
+
+
 v0.4.2 - October 17 2015
 
 * Build: Add `debug` output to `test` script (Ryan Milbourne)

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The [examples](examples) directory contains spectcl code examples, as well as th
 
 ## API Reference
 
-Watch this space. (See #2)
+The Spectcl API is documented on [spectcl.github.io](https://github.com/spectcl/spectcl.github.io/blob/master/api.html).
 
 ## Tests
 

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -487,6 +487,12 @@ module.exports = function Spectcl(options){
          */
         sendEof: function(cb){
             var self = this
+            if(cb){
+                self.child.once('close', function(){
+                    return cb()
+                })
+            }
+
             // child_pty requires us to call kill() directly.
             if(self.child.stdout.ttyname){
                 debug('[sendEof] kill pty')
@@ -494,9 +500,6 @@ module.exports = function Spectcl(options){
             } else {
                 debug('[sendEof] destroy sdtin')
                 self.child.stdin.destroy()
-            }
-            if(cb){
-                return cb()
             }
         },
 

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -453,24 +453,39 @@ module.exports = function Spectcl(options){
 
 
         /**
+         * Called once a condition is met, or after a match handler is called.
+         * @callback Spectcl~sendCallback
+         */
+
+        /**
          * Sends data to the spawned process
          * @param {string} data - Data to send to the current spawned process.
+         * @param {Spectcl~sendCallback} cb - Called once the send is complete.
          * @return {undefined}
          */
-        send: function(data){
+        send: function(data, cb){
             debug('[send] writing to child stdin')
             this.child.stdin.write(data, function(){
-                return
+                debug('[send] wrote to child stdin')
+                if(cb){
+                    return cb()
+                }
             })
         },
 
 
         /**
+         * Called once a condition is met, or after a match handler is called.
+         * @callback Spectcl~sendEofCallback
+         */
+
+        /**
          * Destroy the spawned process' stdin stream.
          * Useful when working with apps that use inquirer.
+         * @param {Spectcl~sendEofCallback} cb - Called once EOF is sent.
          * @return {undefined}
          */
-        sendEof: function(){
+        sendEof: function(cb){
             var self = this
             // child_pty requires us to call kill() directly.
             if(self.child.stdout.ttyname){
@@ -480,7 +495,9 @@ module.exports = function Spectcl(options){
                 debug('[sendEof] destroy sdtin')
                 self.child.stdin.destroy()
             }
-            return
+            if(cb){
+                return cb()
+            }
         },
 
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "spectcl",
   "description": "Spawns and interacts with child processes using spawn / expect commands",
-  "version": "0.4.2",
-  "author": "Greg Cochard <greg@gregcochard.com>",
+  "version": "0.4.3",
+  "author": "Ryan Milbourne <ryan.milbourne@viasat.com>",
   "maintainers": [
     "Greg Cochard <greg@gregcochard.com>",
     "Ryan Milbourne <ryan.milbourne@viasat.com>"

--- a/test/spectcl.js
+++ b/test/spectcl.js
@@ -348,16 +348,35 @@ describe('spectcl', function(){
         })
     })
 
-    describe('sendEof', function(){
-        it('should kill the child process, emitting an exit event', function(done){
+    describe('send', function(){
+        it('should call the cb once data has been written to child', function(done){
             var session = new Spectcl()
-            session.on('exit', function(){
-                done()
-            })
             session.spawn('node --interactive')
             session.expect([
                 '>', function(){
-                    session.sendEof()
+                    assert.notEqual(session.expect_out.match, null, 'null expect_out match')
+                    assert.notEqual(session.expect_out.buffer, '', 'empty expect_out buffer')
+                    session.send('process.exit()\r', function(){
+                        session.child.on('exit', function(){
+                            done()
+                        })
+                    })
+                }
+            ])
+        })
+    })
+
+    describe('sendEof', function(){
+        it('should kill the child process, emitting an exit event', function(done){
+            var session = new Spectcl()
+            session.spawn('node --interactive')
+            session.expect([
+                '>', function(){
+                    session.sendEof(function(){
+                        session.on('exit', function(){
+                            done()
+                        })
+                    })
                 }
             ])
         })

--- a/test/spectcl.js
+++ b/test/spectcl.js
@@ -372,10 +372,21 @@ describe('spectcl', function(){
             session.spawn('node --interactive')
             session.expect([
                 '>', function(){
+                    session.on('exit', function(){
+                        done()
+                    })
+                    session.sendEof()
+                }
+            ])
+        })
+
+        it('should call the callback when given one', function(done){
+            var session = new Spectcl()
+            session.spawn('node --interactive')
+            session.expect([
+                '>', function(){
                     session.sendEof(function(){
-                        session.on('exit', function(){
-                            done()
-                        })
+                        done()
                     })
                 }
             ])


### PR DESCRIPTION
This commit adds optional callbacks to send and sendEof functions to
better support "fire-and-forget" operations.  These are operations where
the issuer does not want to wait around to examine the result of the
command.  Normally such a callback might not be used because a send
would be immediately followed by an expect, but there are times when the
user wants to return only after the command has been written to the
session channel.

Docs are updated to reflect the new callbacks.
Tests are also added to vet the callback.

Resolves #69