### PR TITLE
Make eslint errors fail the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ branches:
 before_install:
     - npm i -g npm
 
+script:
+    - npm run lint && npm test
+
 after_script:
     - if [[ `node --version` == *v0.12* ]]; then cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js; fi
 


### PR DESCRIPTION
Travis should run `eslint` and the build should fail in the event of any style regressions.