### PR TITLE
Update eslint to version 2.1.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
       "no-alert": 2,
       "no-caller": 2,
       "no-else-return": 2,
-      "no-empty-label": 2,
+      "no-labels": [2, {"allowLoop": true, "allowSwitch": true}],
       "no-eval": 2,
       "no-extend-native": 2,
       "no-floating-decimal": 2,
@@ -61,7 +61,7 @@
       "no-trailing-spaces": 2,
       "quotes": [2, "single", "avoid-escape"],
       "semi": [2, "never"],
-      "space-return-throw-case": 2,
+      "keyword-spacing": [2, {"before":true, "after":true, "overrides": {"if":{"after":false},"for":{"after":false},"switch":{"after":false},"catch":{"after":false}}}],
       "spaced-comment": [2, "always", {"exceptions": ["=","-"], "markers":["eslint-disable","eslint-enable","eslint-disable-line","global"]}]
     }
 }

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -139,21 +139,20 @@ Spectcl.prototype.spawn = function (command, cmdParams, cmdOptions, spawnOptions
     }
 
     // Arguments handling
-    if (arguments.length === 2) {
+    if(arguments.length === 2) {
         // Did we get a params array or an options object as the second parameter?
-        if (Array.isArray(cmdParams)) {
+        if(Array.isArray(cmdParams)) {
             cmdOptions = {}
-        }
-        else {
+        } else {
             cmdOptions = cmdParams
             cmdParams = null
         }
     }
-    if (Array.isArray(command)) {
+    if(Array.isArray(command)) {
         cmdParams = command
         command = cmdParams.shift()
     }
-    else if (typeof command === 'string') {
+    else if(typeof command === 'string') {
         command = command.split(' ')
         cmdParams = cmdParams || command.slice(1)
         command = command[0]
@@ -333,7 +332,7 @@ Spectcl.prototype.expect = function(expArr, cb){
           if(expectationCb){
               debug('[expect] [%d] calling handler for %s', self.child.pid, matchedExpectation)
               cbRetVal = expectationCb(matchedExpectation, expectMatch[matchedExpectation] || null, finalCb )
-          } else{
+          } else {
               debug('[expect] [%d] warning: no callback defined for %s', self.child.pid,matchedExpectation)
               return finalCb(null)
           }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "colors": "1.1.2",
     "coveralls": "^2.11.6",
     "dateformat": "^1.0.11",
-    "eslint": "^1.9.0",
+    "eslint": "^2.1.0",
     "gh-got": "^2.4.0",
     "istanbul": "^0.4.2",
     "jsdoc-to-markdown": "^1.3.1",

--- a/test/spectcl.js
+++ b/test/spectcl.js
@@ -82,7 +82,6 @@ mySpawn.setStrategy(function (command, args) {
                 })
             }
         }
-        break
     default:
         return mySpawn.simple(0,'hello world')
     }
@@ -151,7 +150,6 @@ myPtySpawn.setStrategy(function (command, args) {
                 })
             }
         }
-        break
     default:
         return mySpawn.simple(0,'hello world')
     }
@@ -239,7 +237,7 @@ describe('spectcl', function(){
 
         it('should throw an error if command is not string or array', function(done){
             var session = new Spectcl()
-            try{
+            try {
                 session.spawn({'echo': 'hello'}, {})
             } catch(e){
                 assert(e)


### PR DESCRIPTION
This PR updates eslint to `v2.1.0` and fixes lint errors incurred. The new keyword spacing rule forced us to get more strict on if/else/try/catch/for keywords, so I chose to disallow spaces after `if`, `for`, `switch`, and `catch`, while requiring them after all other keywords, and requiring spaces before all keywords. If this seems wrong, let me know and I'll update the rule with the *right* spacing.

Closes #104