### PR TITLE
Modify sendEof to cb w/o waiting for stream close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v0.6.2 - May 10 2016
+
+* modify "sendEof" to invoke callback w/o waiting for child stream closure (Ryan Milbourne)
+* Build: Update dependencies (greenkeeper)
+
+v0.6.1 - April 8 2016
+
+* Build: Remove unused dependencies, makefile (Greg Cochard)
+
 v0.6.0 - February 2 2016
 
 * "expect" function inserts third parameter to callback, the match result

--- a/lib/spectcl.js
+++ b/lib/spectcl.js
@@ -499,11 +499,6 @@ Spectcl.prototype.send = function(data, cb){
  */
 Spectcl.prototype.sendEof = function(cb){
     var self = this
-    if(cb){
-        self.child.once('close', function(){
-            return cb()
-        })
-    }
 
     // child_pty requires us to call kill() directly.
     if(self.child.stdout.ttyname){
@@ -513,6 +508,11 @@ Spectcl.prototype.sendEof = function(cb){
         debug('[sendEof] destroy sdtin')
         self.child.stdin.destroy()
     }
+
+    if(cb){
+        return cb()
+    }
+
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spectcl",
   "description": "Spawns and interacts with child processes using spawn / expect commands",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Ryan Milbourne <ryan.milbourne@viasat.com>",
   "maintainers": [
     "Greg Cochard <greg@gregcochard.com>",


### PR DESCRIPTION
## What does this Pull Request do?
Modify `sendEof()` to invoke its callback w/o waiting for the stream to close.

## Where should the maintainers start when reviewing your request?
lib/spectcl.js, in the `sendEof()` function

## Is there any additional background context you'd like to provide?
Right now `sendEof` waits for stream close before invoking its callback.
This is problematic when sending EOF doesn't close the stream (telnet,
for example).  This commit modifies the function to call the callback
after sending the EOF.

Note that this will also roll the `PATCH` version.

## Are there any relevant issues?
None.

## Questions:
- Does this request add new dependencies to `spectcl`? NO
- Does this request constitute a MAJOR change to `spectcl`'s version? NO